### PR TITLE
Fixed infinite loop when stream does not close itself or throw error

### DIFF
--- a/Sources/ResponseSerializer.swift
+++ b/Sources/ResponseSerializer.swift
@@ -51,6 +51,9 @@ public struct ResponseSerializer: S4.ResponseSerializer {
         case .receiver(let receiver):
             while !receiver.closed {
                 let data = try receiver.receive(upTo: 2014)
+                guard data.count > 0 else {
+                    break
+                }
                 try transport.send(String(data.count, radix: 16).data)
                 try transport.send(newLine)
                 try transport.send(data)

--- a/Tests/HTTPSerializer/HTTPSerializerTests.swift
+++ b/Tests/HTTPSerializer/HTTPSerializerTests.swift
@@ -1,16 +1,48 @@
 import XCTest
 @testable import HTTPSerializer
 
+class StringStream: Stream {
+    let input: String
+    var output = ""
+    var receivedText = false
+
+    init(input: String? = nil) {
+        self.input = input ?? ""
+    }
+
+    var closed: Bool { return false }
+    func close() throws {}
+    func flush(timingOut deadline: Double) throws {}
+
+    func send(_ data: Data, timingOut deadline: Double) throws {
+        self.output += String(data)
+    }
+
+    func receive(upTo byteCount: Int, timingOut deadline: Double) throws -> Data {
+        guard self.receivedText else {
+            self.receivedText = true
+            return Data(self.input)
+        }
+        return Data()
+    }
+}
+
 class HTTPSerializerTests: XCTestCase {
-    func testReality() {
-        XCTAssert(2 + 2 == 4, "Something is severely wrong here.")
+    func testSerializeStream() {
+        let inStream = StringStream(input: "text")
+        let outStream = StringStream()
+        let serializer = ResponseSerializer()
+        let response = Response(body: inStream)
+
+        try! serializer.serialize(response, to: outStream)
+        XCTAssertEqual(outStream.output, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntext\r\n0\r\n\r\n")
     }
 }
 
 extension HTTPSerializerTests {
     static var allTests: [(String, (HTTPSerializerTests) -> () throws -> Void)] {
         return [
-           ("testReality", testReality),
+           ("testSerializeStream", testSerializeStream),
         ]
     }
 }


### PR DESCRIPTION
Now the response serializer will exit once it gets a zero-length response from its stream.

This was particularly causing me a problem on linux with a FileStream. It infinite loops because the file stream does not close itself at the end of the file and it also does not throw an error.
